### PR TITLE
Add migrations for roles and connect users with players

### DIFF
--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,23 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass
+    

--- a/backend/migrations/versions/20240409_01_create_core_tables.py
+++ b/backend/migrations/versions/20240409_01_create_core_tables.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "20240409_01"
-down_revision = None
+down_revision = "20260414_01"
 branch_labels = None
 depends_on = None
 
@@ -21,14 +21,18 @@ def upgrade() -> None:
     op.create_table(
         "players",
         sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
         sa.Column("name", sa.String(length=250), nullable=False),
-        sa.Column("email", sa.String(length=250), nullable=False),
         sa.Column("phone", sa.BigInteger(), nullable=True),
         sa.Column("photo", sa.LargeBinary(), nullable=True),
-        sa.UniqueConstraint("email", name="uq_players_email"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_players_user_id",
+            ondelete="CASCADE",
+        ),
     )
-    op.create_index("ix_players_email", "players", ["email"])
-
+    op.create_index("ix_players_user_id", "players", ["user_id"])
     op.create_table(
         "team_memberships",
         sa.Column("player_id", sa.BigInteger(), nullable=False),
@@ -48,6 +52,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("player_id", "team_id"),
     )
+
     op.create_index("ix_team_memberships_player_id", "team_memberships", ["player_id"])
     op.create_index("ix_team_memberships_team_id", "team_memberships", ["team_id"])
 
@@ -56,6 +61,7 @@ def downgrade() -> None:
     op.drop_index("ix_team_memberships_team_id", table_name="team_memberships")
     op.drop_index("ix_team_memberships_player_id", table_name="team_memberships")
     op.drop_table("team_memberships")
-    op.drop_index("ix_players_email", table_name="players")
+    op.drop_index("ix_players_user_id", table_name="players")
     op.drop_table("players")
+
     op.drop_table("teams")

--- a/backend/migrations/versions/20260414_01_create_users_table.py
+++ b/backend/migrations/versions/20260414_01_create_users_table.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "20260414_01"
-down_revision = "20240409_01"
+down_revision = None
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/20260415_01_create_matches_table.py
+++ b/backend/migrations/versions/20260415_01_create_matches_table.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "20260415_01"
-down_revision = "20260414_01"
+down_revision = "20240409_01"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/20260427_05_create_roles_table.py
+++ b/backend/migrations/versions/20260427_05_create_roles_table.py
@@ -1,0 +1,59 @@
+"""20260427_05_create_roles_table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20260427_05'
+down_revision = '20260421_03'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 🔹 Tabla de roles
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.UniqueConstraint("name", name="uq_roles_name"),
+    )
+
+    # 🔹 Tabla intermedia user_roles (muchos a muchos)
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("role_id", sa.BigInteger(), nullable=False),
+
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_user_roles_user_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["roles.id"],
+            name="fk_user_roles_role_id",
+            ondelete="CASCADE",
+        ),
+
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+    )
+
+    op.create_index("ix_user_roles_user_id", "user_roles", ["user_id"])
+    op.create_index("ix_user_roles_role_id", "user_roles", ["role_id"])
+
+    #op.execute("""
+     #   INSERT INTO roles (name) VALUES
+      #  ('admin'),
+       # ('coach'),
+        #('player')
+    #""")
+
+
+def downgrade():
+    op.drop_index("ix_user_roles_role_id", table_name="user_roles")
+    op.drop_index("ix_user_roles_user_id", table_name="user_roles")
+    op.drop_table("user_roles")
+    op.drop_table("roles")
+    

--- a/backend/migrations/versions/20260428_01_add_team_contact_fields.py
+++ b/backend/migrations/versions/20260428_01_add_team_contact_fields.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "20260428_01"
-down_revision = "20260421_03"
+down_revision = "20260427_05"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Se agrego la migración de roles y se añadió la conexión entre users y players.
Para ejecutar las migraciones se añadió el archivo script.py.mako. 